### PR TITLE
Get Apps - Throw error on get empty array

### DIFF
--- a/custom_modules/MongoDbController/MongoControllerHelpers.js
+++ b/custom_modules/MongoDbController/MongoControllerHelpers.js
@@ -40,6 +40,16 @@ class MongoControllerHelpers
                 
                 // Done searching, close connection
                 await connection.close();
+
+                // Empty results
+                if (array.length === 0)
+                {
+                    const errResults = new MongoResults({
+                        error: `No ${Model.name}s were found`,
+                        status: 500,
+                    });
+                    reject(errResults);
+                }
                 
                 // Parse array into an array of models
                 const models = MongoControllerHelpers.getAsModels(array, Model);

--- a/src/api/v1/public/routes/apps.js
+++ b/src/api/v1/public/routes/apps.js
@@ -270,7 +270,7 @@ app.patch("/", function(req, res)
             {
                 const errResponse = new InternalServerErrorResponse({
                     res,
-                    message: getFailedMessageForGettingAppOnUpdate(findParams),
+                    message: getUpdateMessageForNoAppsFound(findParams),
                 });
                 res.json(errResponse);
             }
@@ -320,7 +320,7 @@ function getSuccessMessageForUpdateApps(findParams)
 }
 
 // Get apps - helper
-function getFailedMessageForGettingAppOnUpdate(query)
+function getUpdateMessageForNoAppsFound(query)
 {
     let str = "Failed to retrieve an app";
 

--- a/src/api/v1/public/routes/apps.js
+++ b/src/api/v1/public/routes/apps.js
@@ -60,12 +60,26 @@ app.get("/", function(req, res)
         })
         .catch(function (err)
         {
-            const errResponse = new BadRequestErrorResponse({
-                res,
-                message: getFailedMessageForGetApps(req.query),
-                err,
-            });
-            res.json(errResponse);
+            // Mongo Error
+            if (err && err.status && err.status === 500)
+            {
+                const errResponse = new InternalServerErrorResponse({
+                    res,
+                    message: getGetMessageForNoAppsFound(req.query),
+                });
+                res.json(errResponse);
+            }
+
+            // Other error
+            else
+            {
+                const errResponse = new BadRequestErrorResponse({
+                    res,
+                    message: getFailedMessageForGetApps(req.query),
+                    err,
+                });
+                res.json(errResponse);
+            }
         });
     })
     .catch(function (err)
@@ -82,6 +96,33 @@ app.get("/", function(req, res)
 function getSuccessMessageForGetApps(query)
 {
     let str = "Successfully retrieved all apps";
+
+    if (query.env)
+    {
+        str += ` from ${query.env}`;
+    }
+
+    if (query.searchName)
+    {
+        str += ` named ${query.searchName}`;
+    }
+
+    if (query._id)
+    {
+        str += ` with ID ${query._id}`;
+    }
+    else if (query.id)
+    {
+        str += ` with ID ${query.id}`;
+    }
+
+    return str;
+}
+
+// Get apps - helper
+function getGetMessageForNoAppsFound(query)
+{
+    let str = "No apps were found";
 
     if (query.env)
     {


### PR DESCRIPTION
Previously, if you got an empty array, it would return that with a success message and a 200 status. Now, it will return an error with a 500 status. 